### PR TITLE
Fix compatibility with js/html5 & BabylonHx

### DIFF
--- a/oimohx/ds/Float32Array.hx
+++ b/oimohx/ds/Float32Array.hx
@@ -1,0 +1,12 @@
+package oimohx.ds;
+
+
+/**
+	Created by Alexander "fzzr" Kozlovskij
+ **/
+typedef Float32Array =
+#if (babylonhx && (js || purejs || html5 || web))
+com.babylonhx.utils.typedarray.Float32Array;
+#else
+haxe.ds.Vector<Float>;
+#end

--- a/oimohx/math/Mat33.hx
+++ b/oimohx/math/Mat33.hx
@@ -18,10 +18,10 @@
  */
 package oimohx.math;
 
+import oimohx.ds.Float32Array;
 import haxe.ds.Vector;
 import oimohx.math.Mat44;
 import oimohx.math.Quat;
-import com.babylonhx.utils.typedarray.Float32Array;
 
 /**
  * A 3x3 matrix. This supports rotation, skewing, and scaling transformations.
@@ -29,12 +29,8 @@ import com.babylonhx.utils.typedarray.Float32Array;
  */
 class Mat33 {
 	
-    #if js
 	public var elements:Float32Array = new Float32Array(9);
-	#else
-	public var elements:Vector<Float> = new Vector<Float>(9);	
-	#end
-	    
+
     /**
 	 * Constructor.
 	 * If the parameters are empty, the matrix will be set to the itentity matrix.

--- a/oimohx/math/Mat44.hx
+++ b/oimohx/math/Mat44.hx
@@ -18,9 +18,9 @@
  */
 package oimohx.math;
 
+import oimohx.ds.Float32Array;
 import haxe.ds.Vector;
 import oimohx.math.Quat;
-import com.babylonhx.utils.typedarray.Float32Array;
 
 /**
  * A 4x4 matrix. This supports three-dimentional transformations perfectly.
@@ -28,12 +28,8 @@ import com.babylonhx.utils.typedarray.Float32Array;
  */
 class Mat44 {
 	
-    #if js
 	public var elements:Float32Array = new Float32Array(16);
-	#else
-	public var elements:Vector<Float> = new Vector<Float>(16);	
-	#end
-	    
+
     /**
 	 * Constructor.
 	 * If the parameters are empty, the matrix will be set to the identity matrix.

--- a/oimohx/physics/dynamics/RigidBody.hx
+++ b/oimohx/physics/dynamics/RigidBody.hx
@@ -18,6 +18,7 @@
  */
 package oimohx.physics.dynamics;
 
+import oimohx.ds.Float32Array;
 import haxe.ds.Vector;
 import oimohx.math.Mat44;
 import oimohx.physics.dynamics.World;
@@ -29,7 +30,6 @@ import oimohx.physics.collision.shape.MassInfo;
 import oimohx.physics.collision.shape.Shape;
 import oimohx.physics.constraint.contact.ContactLink;
 import oimohx.physics.constraint.joint.JointLink;
-import com.babylonhx.utils.typedarray.Float32Array;
 
 /**
  * 剛体のクラスです。
@@ -843,13 +843,10 @@ class RigidBody {
     inline public function getQuaternion():Quat {
         return new Quat().setFromRotationMatrix(this.rotation);
     }*/
-    inline public function getMatrix(): #if (js || purejs || html5 || web) Float32Array #else Vector<Float> #end {
+    inline public function getMatrix():Float32Array
+    {
         var m = this.matrix.elements;
-		#if js
 		var r:Float32Array = new Float32Array(9);
-		#else
-        var r:Vector<Float>;
-		#end
 		var p:Vec3 = null;
         if(!this.sleeping){
             // rotation matrix


### PR DESCRIPTION
Fix compatibility with js/html5 & BabylonHx: selecting `haxe.ds.Vector<Float>` vs. `com.babylonhx.utils.typedarray.Float32Array`.
